### PR TITLE
Fix shield link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Yet anotherReact link preview component with cards for web without a specific ba
 
 [![npm version](https://badge.fury.io/js/react-tiny-link.svg)](https://badge.fury.io/js/react-tiny-link) ![npm](https://img.shields.io/npm/v/react-tiny-link.svg) ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/winhtaikaung/react-tiny-link.svg) ![NPM](https://img.shields.io/npm/l/react-tiny-link.svg)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/contributors/winhtaikaung/react-tiny-link?style=flat-square&color=orange&label=all%20contributors)](#contributors)
 
 [![NPM](https://nodei.co/npm/react-tiny-link.png)](https://nodei.co/npm/react-tiny-link/)
 


### PR DESCRIPTION
fix the all-contributor shield link which was showing only 1 even if there were more contributors

**Before**
![all-contributors-shield](https://user-images.githubusercontent.com/9588306/82729046-0c549d00-9d14-11ea-9e5a-496a89d9dca6.png)

**After**
![all-contributors-shield-after](https://user-images.githubusercontent.com/9588306/82729070-38701e00-9d14-11ea-9a5f-c7760dd8d02f.png)

